### PR TITLE
🐛 "Updated product link in landing page to use product ID instead of …

### DIFF
--- a/resources/views/livewire/landingpage.blade.php
+++ b/resources/views/livewire/landingpage.blade.php
@@ -81,7 +81,7 @@
                                                         {{ isset($product->sale_price) ? number_format($product->sale_price) : number_format($product->price) }}
                                                     </span>
                                                 </p>
-                                                <a href="{{ route('order', ['product_name' => Str::slug($product->product_name)]) }}" target="_blank"
+                                                <a href="{{ route('order', ['id' => Str::slug($product->id)]) }}" target="_blank"
                                                     class="btn border btn-primary rounded-pill px-3 text-white">
                                                     <i class="fab fa-whatsapp me-2 text-white"></i>Pesan</a>
                                             </div>


### PR DESCRIPTION
…product name"