### PR TITLE
🐛 "Removed `clearAdCache` and `clearCache` methods in Ad and Product …

### DIFF
--- a/app/Models/Ad.php
+++ b/app/Models/Ad.php
@@ -16,27 +16,18 @@ class Ad extends Model
         parent::boot();
 
         static::creating(function () {
-            self::clearAdCache();
+            Cache::forget("ads");
+            Cache::forget("ads-promo");
+            Cache::forget("landingpage-html-20");
         });
 
         static::updating(function ($model) {
-            if ($model->isDirty('image') && $model->getOriginal('image') !== null) {
+            if ($model->isDirty('image') && ($model->getOriginal('image') !== null)) {
                 Storage::disk('public')->delete($model->getOriginal('image'));
             }
-            self::clearAdCache();
+            Cache::forget("ads");
+            Cache::forget("ads-promo");
+            Cache::forget("landingpage-html-20");
         });
-    }
-
-    private static function clearAdCache()
-    {
-        $keys = [
-            "ads",
-            "ads-promo",
-            "landingpage-html-20",
-        ];
-
-        foreach ($keys as $key) {
-            Cache::forget($key);
-        }
     }
 }

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -12,21 +12,6 @@ class Product extends Model
 {
     use HasFactory;
 
-    protected const CACHE_KEYS = [
-        "products-20",
-        "landingpage-html-20",
-        "products-promo-20",
-        "products-bunga-papan-20",
-        "products-bunga-meja-20",
-        "products-bunga-papan-congratulation-20",
-        "products-bunga-papan-dukacita-20",
-        "products-bunga-papan-happy-wedding-20",
-        "products-bunga-papan-selamat-20",
-        "products-bunga-salib-20",
-        "products-bunga-standing-20",
-        "products-hand-bouquet-20",
-    ];
-
     public function category()
     {
         return $this->belongsTo(Category::class);
@@ -37,21 +22,37 @@ class Product extends Model
         parent::boot();
 
         static::creating(function () {
-            self::clearCache();
+            Cache::forget("products-20"); // delete cache landing page product
+            Cache::forget("landingpage-html-20"); // delete cache landing page product
+            Cache::forget("products-promo-20"); // delete cache promopage
+            Cache::forget("products-bunga-papan-20"); // delete cache bunga papan
+            Cache::forget("products-bunga-meja-20"); // delete cache bunga meja
+            Cache::forget("products-bunga-papan-congratulation-20"); // delete cache bunga papan congrats
+            Cache::forget("products-bunga-papan-dukacita-20"); // delete cache bunga papan duka
+            Cache::forget("products-bunga-papan-happy-wedding-20"); // delete cache bunga papan wedding
+            Cache::forget("products-bunga-papan-selamat-20"); // delete cache bunga papan selamat
+            Cache::forget("products-bunga-salib-20"); // delete cache bunga salib
+            Cache::forget("products-bunga-standing-20"); // delete cache bunga standing
+            Cache::forget("products-hand-bouquet-20"); // delete cache hand bouquet
         });
 
         static::updating(function ($model) {
             if ($model->isDirty('image') && ($model->getOriginal('image') !== null)) {
                 Storage::disk('public')->delete($model->getOriginal('image'));
             }
-            self::clearCache();
-        });
-    }
 
-    protected static function clearCache()
-    {
-        foreach (self::CACHE_KEYS as $key) {
-            Cache::forget($key);
-        }
+            Cache::forget("products-20"); // delete cache landing page product
+            Cache::forget("landingpage-html-20"); // delete cache landing page product
+            Cache::forget("products-promo-20"); // delete cache promopage
+            Cache::forget("products-bunga-papan-20"); // delete cache bunga papan
+            Cache::forget("products-bunga-meja-20"); // delete cache bunga meja
+            Cache::forget("products-bunga-papan-congratulation-20"); // delete cache bunga papan congrats
+            Cache::forget("products-bunga-papan-dukacita-20"); // delete cache bunga papan duka
+            Cache::forget("products-bunga-papan-happy-wedding-20"); // delete cache bunga papan wedding
+            Cache::forget("products-bunga-papan-selamat-20"); // delete cache bunga papan selamat
+            Cache::forget("products-bunga-salib-20"); // delete cache bunga salib
+            Cache::forget("products-bunga-standing-20"); // delete cache bunga standing
+            Cache::forget("products-hand-bouquet-20"); // delete cache hand bouquet
+        });
     }
 }


### PR DESCRIPTION
…models, replaced with explicit Cache::forget calls."